### PR TITLE
Use thetvdb.com rather than www.thetvdb.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ The docstring for `Tvdb.__init__` lists all initialisation arguments, including 
 
 There are several exceptions you may catch, these can be imported from `tvdb_api`:
 
-- `tvdb_error` - this is raised when there is an error communicating with [www.thetvdb.com][tvdb] (a network error most commonly)
+- `tvdb_error` - this is raised when there is an error communicating with [thetvdb.com][tvdb] (a network error most commonly)
 - `tvdb_userabort` - raised when a user aborts the Select Series dialog (by `ctrl+c`, or entering `q`)
 - `tvdb_shownotfound` - raised when `t['show name']` cannot find anything
 - `tvdb_seasonnotfound` - raised when the requested series (`t['show name][99]`) does not exist
@@ -105,5 +105,5 @@ Remember a simple list of actors is accessible via the default Show data:
     >>> t['scrubs']['actors']
     u'|Zach Braff|Donald Faison|Sarah Chalke|Christa Miller|Aloma Wright|Robert Maschio|Sam Lloyd|Neil Flynn|Ken Jenkins|Judy Reyes|John C. McGinley|Travis Schuldt|Johnny Kastl|Heather Graham|Michael Mosley|Kerry Bish\xe9|Dave Franco|Eliza Coupe|'
 
-[tvdb]: http://www.thetvdb.com
+[tvdb]: http://thetvdb.com
 [tvnamer]: http://github.com/dbr/tvnamer

--- a/tests/test_tvdb_api.py
+++ b/tests/test_tvdb_api.py
@@ -229,7 +229,7 @@ class test_tvdb_misc(unittest.TestCase):
         """Check valid_languages is up-to-date (compared to languages.xml)
         """
         et = self.t._getetsrc(
-            "http://www.thetvdb.com/api/%s/languages.xml" % (
+            "http://thetvdb.com/api/%s/languages.xml" % (
                 self.t.config['apikey']
             )
         )

--- a/tvdb_api.py
+++ b/tvdb_api.py
@@ -5,7 +5,7 @@
 #repository:http://github.com/dbr/tvdb_api
 #license:unlicense (http://unlicense.org/)
 
-"""Simple-to-use Python interface to The TVDB's API (www.thetvdb.com)
+"""Simple-to-use Python interface to The TVDB's API (thetvdb.com)
 
 Example usage:
 
@@ -448,7 +448,7 @@ class Tvdb:
             logging.basicConfig(level=logging.DEBUG)
 
 
-        # List of language from http://www.thetvdb.com/api/0629B785CE550C8D/languages.xml
+        # List of language from http://thetvdb.com/api/0629B785CE550C8D/languages.xml
         # Hard-coded here as it is realtively static, and saves another HTTP request, as
         # recommended on http://thetvdb.com/wiki/index.php/API:languages.xml
         self.config['valid_languages'] = [
@@ -477,7 +477,7 @@ class Tvdb:
 
         # The following url_ configs are based of the
         # http://thetvdb.com/wiki/index.php/Programmers_API
-        self.config['base_url'] = "http://www.thetvdb.com"
+        self.config['base_url'] = "http://thetvdb.com"
 
         if self.config['search_all_languages']:
             self.config['url_getSeries'] = u"%(base_url)s/api/GetSeries.php?seriesname=%%s&language=all" % self.config
@@ -665,7 +665,7 @@ class Tvdb:
 
     def _parseBanners(self, sid):
         """Parses banners XML, from
-        http://www.thetvdb.com/api/[APIKEY]/series/[SERIES ID]/banners.xml
+        http://thetvdb.com/api/[APIKEY]/series/[SERIES ID]/banners.xml
 
         Banners are retrieved using t['show name]['_banners'], for example:
 
@@ -673,7 +673,7 @@ class Tvdb:
         >>> t['scrubs']['_banners'].keys()
         ['fanart', 'poster', 'series', 'season']
         >>> t['scrubs']['_banners']['poster']['680x1000']['35308']['_bannerpath']
-        u'http://www.thetvdb.com/banners/posters/76156-2.jpg'
+        u'http://thetvdb.com/banners/posters/76156-2.jpg'
         >>>
 
         Any key starting with an underscore has been processed (not the raw
@@ -717,7 +717,7 @@ class Tvdb:
 
     def _parseActors(self, sid):
         """Parsers actors XML, from
-        http://www.thetvdb.com/api/[APIKEY]/series/[SERIES ID]/actors.xml
+        http://thetvdb.com/api/[APIKEY]/series/[SERIES ID]/actors.xml
 
         Actors are retrieved using t['show name]['_actors'], for example:
 
@@ -734,7 +734,7 @@ class Tvdb:
         >>> actors[0]['name']
         u'Zach Braff'
         >>> actors[0]['image']
-        u'http://www.thetvdb.com/banners/actors/43640.jpg'
+        u'http://thetvdb.com/banners/actors/43640.jpg'
 
         Any key starting with an underscore has been processed (not the raw
         data from the XML)

--- a/tvdb_exceptions.py
+++ b/tvdb_exceptions.py
@@ -20,7 +20,7 @@ class tvdb_exception(Exception):
     pass
 
 class tvdb_error(tvdb_exception):
-    """An error with www.thetvdb.com (Cannot connect, for example)
+    """An error with thetvdb.com (Cannot connect, for example)
     """
     pass
 
@@ -31,17 +31,17 @@ class tvdb_userabort(tvdb_exception):
     pass
 
 class tvdb_shownotfound(tvdb_exception):
-    """Show cannot be found on www.thetvdb.com (non-existant show)
+    """Show cannot be found on thetvdb.com (non-existant show)
     """
     pass
 
 class tvdb_seasonnotfound(tvdb_exception):
-    """Season cannot be found on www.thetvdb.com
+    """Season cannot be found on thetvdb.com
     """
     pass
 
 class tvdb_episodenotfound(tvdb_exception):
-    """Episode cannot be found on www.thetvdb.com
+    """Episode cannot be found on thetvdb.com
     """
     pass
 


### PR DESCRIPTION
The domain without the www subdomain is allegedly more reliable, giving fewer 503 errors. See http://forums.thetvdb.com/viewtopic.php?f=4&t=12909

It has helped in my case at least.
