### PR TITLE
Adding option for DVD ordering

### DIFF
--- a/tests/test_tvdb_api.py
+++ b/tests/test_tvdb_api.py
@@ -505,6 +505,27 @@ class test_tvdb_zip(unittest.TestCase):
         self.assertEquals(self.t['My Name Is Earl'][1][4]['episodename'], 'Faked His Own Death')
 
 
+class test_tvdb_show_ordering(unittest.TestCase):
+    # Used to store the cached instance of Tvdb()
+    t_dvd = None
+    t_air = None
+
+    def setUp(self):
+        if self.t_dvd is None:
+            self.t_dvd = tvdb_api.Tvdb(cache = True, useZip = True, dvdorder=True)
+
+        if self.t_air is None:
+            self.t_air = tvdb_api.Tvdb(cache = True, useZip = True)
+
+    def test_ordering(self):
+        """Test Tvdb.search method
+        """
+        self.assertEquals(u'The Train Job', self.t_air['Firefly'][1][1]['episodename'])
+        self.assertEquals(u'Serenity', self.t_dvd['Firefly'][1][1]['episodename'])
+
+        self.assertEquals(u'The Cat & the Claw (Part 1)', self.t_air['Batman The Animated Series'][1][1]['episodename'])
+        self.assertEquals(u'On Leather Wings', self.t_dvd['Batman The Animated Series'][1][1]['episodename'])
+
 class test_tvdb_show_search(unittest.TestCase):
     # Used to store the cached instance of Tvdb()
     t = None

--- a/tvdb_api.py
+++ b/tvdb_api.py
@@ -306,7 +306,8 @@ class Tvdb:
                 search_all_languages = False,
                 apikey = None,
                 forceConnect=False,
-                useZip=False):
+                useZip=False,
+                dvdorder=False):
 
         """interactive (True/False):
             When True, uses built-in console UI is used to select the correct show.
@@ -408,6 +409,7 @@ class Tvdb:
 
         self.config['useZip'] = useZip
 
+        self.config['dvdorder'] = dvdorder
 
         if cache is True:
             self.config['cache_enabled'] = True
@@ -811,8 +813,20 @@ class Tvdb:
         epsEt = self._getetsrc( url, language=language)
 
         for cur_ep in epsEt.findall("Episode"):
-            seas_no = int(cur_ep.find('SeasonNumber').text)
-            ep_no = int(cur_ep.find('EpisodeNumber').text)
+
+            if self.config['dvdorder']:
+                log().debug('Using DVD ordering.')
+                use_dvd = cur_ep.find('DVD_season').text != None and cur_ep.find('DVD_episodenumber').text != None
+            else:
+                use_dvd = False
+
+            if use_dvd:
+                seas_no = int(cur_ep.find('DVD_season').text)
+                ep_no   = int(float(cur_ep.find('DVD_episodenumber').text))
+            else:
+                seas_no = int(cur_ep.find('SeasonNumber').text)
+                ep_no = int(cur_ep.find('EpisodeNumber').text)
+
             for cur_item in cur_ep.getchildren():
                 tag = cur_item.tag.lower()
                 value = cur_item.text


### PR DESCRIPTION
This corresponds with a PR I am making for the Sick-Beard project that allows for ordering the show episodes by their DVD order instead of their airdate order.

https://github.com/midgetspy/Sick-Beard/pull/742

This is an important option for shows like "Batman: The Animated Series" and "Firefly" where the network screwed up the air ordering but fixed it in a subsequent DVD release.
