### PR TITLE
fix ShowContainer cache resizing

### DIFF
--- a/tvdb_api.py
+++ b/tvdb_api.py
@@ -65,16 +65,12 @@ class ShowContainer(dict):
 
         #keep only the 100th latest results
         if time.time() - self._lastgc > 20:
-            tbd = self._stack[:-100]
-            i = 0
-            for o in tbd:
+            for o in self._stack[:-100]:
                 del self[o]
-                del self._stack[i]
-                i += 1
+            self._stack = self._stack[-100:]
 
             self._lastgc = time.time()
-            del tbd
-                    
+
         super(ShowContainer, self).__setitem__(key, value)
 
 


### PR DESCRIPTION
The old code would end up doing effectively `del self._stack[0]; del self._stack[1]; del self._stack[2]` and so on. This isn't what was intended, since after `del self._stack[0]` the thing that was previously 1 is now 0. This meant that the cache was being cleared incorrectly, and if there were a lot of things in the cache between GCs then you could get an `IndexError`. It also moves the entire list around in memory over and over. 

Instead, we can just assign the variable to a sublist of the old one, which (a) doesn't crash and (b) takes one memory copy instead of `len(self._stack) - 100`.
