### PR TITLE
Fixes for API V2

### DIFF
--- a/tests/test_tvdb_api.py
+++ b/tests/test_tvdb_api.py
@@ -276,8 +276,9 @@ class TestTvdbBanners:
         """
         for banner_type, banner_data in self.t['scrubs']['_banners'].items():
             for res, res_data in banner_data.items():
-                for bid, banner_info in res_data.items():
-                    assert banner_info['_bannerpath'].startswith("http://") == True
+                if res != 'raw':
+                    for bid, banner_info in res_data.items():
+                        assert banner_info['_bannerpath'].startswith("http://") == True
 
     @pytest.mark.skip('В новом API нет картинки у эпизода')
     def test_episode_image(self):

--- a/tvdb_exceptions.py
+++ b/tvdb_exceptions.py
@@ -13,13 +13,16 @@ __version__ = "2.0-dev"
 
 import logging
 
-__all__ = ["tvdb_error", "tvdb_userabort", "tvdb_shownotfound",
-"tvdb_seasonnotfound", "tvdb_episodenotfound", "tvdb_attributenotfound"]
+__all__ = ["tvdb_error", "tvdb_userabort", "tvdb_notauthorized", "tvdb_shownotfound",
+"tvdb_seasonnotfound", "tvdb_episodenotfound", "tvdb_attributenotfound",
+"tvdb_resourcenotfound", "tvdb_invalidlanguage"]
 
 logging.getLogger(__name__).warning(
     "tvdb_exceptions module is deprecated - use classes directly from tvdb_api instead")
 
 from tvdb_api import (
-    tvdb_error, tvdb_userabort, tvdb_shownotfound,
-    tvdb_seasonnotfound, tvdb_episodenotfound, tvdb_attributenotfound
+    tvdb_error, tvdb_userabort, tvdb_notauthorized, tvdb_shownotfound,
+    tvdb_seasonnotfound, tvdb_episodenotfound,
+    tvdb_resourcenotfound, tvdb_invalidlanguage,
+    tvdb_attributenotfound
 )


### PR DESCRIPTION
* More Logging
* parameter keys assigned correctly
* Cache uses Accept-Language as part of the key but nothing else from
  the headers
* Cache is pruned at start
* Additional exceptions for new errors
* Check cache before authorization so there is no network traffic
  if not required
* Add langauge key for v1 compatability
* Add extra banners keys
* Add raw banners for easier filtering