### PR TITLE
Fix ImportError: cannot import name '_to_bytes' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename exceptions to conventional PEP8 naming syntax, e.g `tvdb_error` becomes `TvdbError`, `tvdb_episodenotfound` becomes `TvdbEpisodeNotFound` etc. All exceptions have changed. Backwards-compatible bindings to old names exist until next version.
 - Deprecate `Tvdb(forceConnect=...)` argument - had no effect in recent versions, and argument removed in next version.
 - New `TvdbDataNotFound` exception allows catching of all missing-data exceptions in on (`TvdbShowNotFound`, `TvdbSeasonNotFound`, `TvdbEpisodeNotFound`, `TvdbResourceNotFound` are now all subclasses of this)
+- Fix `ImportError: cannot import name '_to_bytes'` error due to change in [requests-cache 0.6.0](https://github.com/reclosedev/requests-cache/blob/master/HISTORY.md#060-2021-04-09) - [issue #92](https://github.com/dbr/tvdb_api/issues/92)
 
 ## `3.0.2` - 2020-05-16
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description_content_type='text/markdown',
 
     py_modules=['tvdb_api'],
-    install_requires=['requests_cache', 'requests'],
+    install_requires=['requests_cache<0.6.0', 'requests'],
 
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This constrains the requests-cache package to a version older than
[0.6.0][1] in which the `_to_bytes` method was removed. This [method is
used][2] in tvdb_api. Once use of the `_to_bytes` methods is removed
from tvdb_api, this version contraint can be removed.

Fixes #92

[1]: https://github.com/reclosedev/requests-cache/blob/master/HISTORY.md#060-2021-04-09
[2]: https://github.com/dbr/tvdb_api/blob/92e8c7cdf5bc1d923f9ed97dacbfd2b52bb4c893/tvdb_api.py