### PR TITLE
fix working with newer requests-cache versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description_content_type='text/markdown',
 
     py_modules=['tvdb_api'],
-    install_requires=['requests_cache<0.6.0', 'requests'],
+    install_requires=['requests_cache', 'requests'],
 
     classifiers=[
         "Intended Audience :: Developers",

--- a/tvdb_api.py
+++ b/tvdb_api.py
@@ -31,7 +31,11 @@ import hashlib
 
 import requests
 import requests_cache
-from requests_cache.backends.base import _to_bytes, _DEFAULT_HEADERS
+
+_DEFAULT_HEADERS = requests.utils.default_headers()
+
+def _to_bytes(s, encoding='utf-8'):
+    return s if isinstance(s, bytes) else bytes(s, encoding)
 
 
 IS_PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
Just inline the simple internal symbols that were being imported
from requests-cache (since it no longer exports them).

Fixes #94.