### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/tests/test_tvdb_api.py
+++ b/tests/test_tvdb_api.py
@@ -46,7 +46,7 @@ if IS_PY2:
     FileNotFoundError = IOError
 
 
-# By default tests use persistent (commited to Git) cache.
+# By default tests use persistent (committed to Git) cache.
 # Setting this env-var allows the cache to be populated.
 # This is necessary if, say, adding new test case or TVDB response changes.
 # It is recommended to clear the cache directory before re-populating the cache.

--- a/tvdb_api.py
+++ b/tvdb_api.py
@@ -96,7 +96,7 @@ class TvdbDataNotFound(TvdbBaseException):
 
 
 class TvdbShowNotFound(TvdbDataNotFound):
-    """Show cannot be found on thetvdb.com (non-existant show)
+    """Show cannot be found on thetvdb.com (non-existent show)
     """
 
     pass


### PR DESCRIPTION
There are small typos in:
- tests/test_tvdb_api.py
- tvdb_api.py

Fixes:
- Should read `existent` rather than `existant`.
- Should read `committed` rather than `commited`.

Closes #95