### PR TITLE
Fix for newer requests-cache

### DIFF
--- a/tests/test_tvdb_api.py
+++ b/tests/test_tvdb_api.py
@@ -103,14 +103,12 @@ class FileCache(requests_cache.backends.base.BaseCache):
         self.keys_map = FileCacheDict(base_dir=fc_base_dir)
 
 
-requests_cache.backends.registry['tvdb_api_file_cache'] = FileCache
-
 
 def get_test_cache_session():
     here = os.path.dirname(os.path.abspath(__file__))
     additional = "_py2" if sys.version_info[0] == 2 else ""
     sess = requests_cache.CachedSession(
-        backend="tvdb_api_file_cache",
+        backend="filesystem",
         fc_base_dir=os.path.join(here, "httpcache%s" % additional),
         include_get_headers=True,
         allowable_codes=(200, 404),

--- a/tvdb_api.py
+++ b/tvdb_api.py
@@ -528,7 +528,7 @@ class Actor(dict):
         return "<Actor %r>" % self.get("name")
 
 
-def create_key(self, request):
+def create_key(self, request, **kwargs):
     """A new cache_key algo is required as the authentication token
     changes with each run. Also there are other header params which
     also change with each request (e.g. timestamp). Excluding all
@@ -544,7 +544,7 @@ def create_key(self, request):
     cache is to be used thus saving host and network traffic.
     """
 
-    if self._ignored_parameters:
+    if self.ignored_parameters:
         url, body = self._remove_ignored_parameters(request)
     else:
         url, body = request.url, request.body
@@ -554,7 +554,7 @@ def create_key(self, request):
     if request.body:
         key.update(_to_bytes(body))
     else:
-        if self._include_get_headers and request.headers != _DEFAULT_HEADERS:
+        if self.match_headers and request.headers != _DEFAULT_HEADERS:
             for name, value in sorted(request.headers.items()):
                 # include only Accept-Language as it is important for context
                 if name in ['Accept-Language']:


### PR DESCRIPTION
These changes fix errors with newer requests-cache. Tested against requests-cache 0.9.8, the version in Debian 12.

Fixes https://github.com/dbr/tvnamer/issues/210#issuecomment-1207181564